### PR TITLE
Fixed the order of deleting and closing temporary files and folders

### DIFF
--- a/SpreadsheetReader_XLSX.php
+++ b/SpreadsheetReader_XLSX.php
@@ -321,19 +321,7 @@
 		 */
 		public function __destruct()
 		{
-			foreach ($this -> TempFiles as $TempFile)
-			{
-				@unlink($TempFile);
-			}
-
-			// Better safe than sorry - shouldn't try deleting '.' or '/', or '..'.
-			if (strlen($this -> TempDir) > 2)
-			{
-				@rmdir($this -> TempDir.'xl'.DIRECTORY_SEPARATOR.'worksheets');
-				@rmdir($this -> TempDir.'xl');
-				@rmdir($this -> TempDir);
-			}
-
+			// 1. Close files and release handles
 			if ($this -> Worksheet && $this -> Worksheet instanceof XMLReader)
 			{
 				$this -> Worksheet -> close();
@@ -355,6 +343,20 @@
 			if ($this -> WorkbookXML)
 			{
 				unset($this -> WorkbookXML);
+			}
+			
+			// 2. Delete temporary files and directories
+			foreach ($this -> TempFiles as $TempFile)
+			{
+				@unlink($TempFile);
+			}
+
+			// Better safe than sorry - shouldn't try deleting '.' or '/', or '..'.
+			if (strlen($this -> TempDir) > 2)
+			{
+				@rmdir($this -> TempDir.'xl'.DIRECTORY_SEPARATOR.'worksheets');
+				@rmdir($this -> TempDir.'xl');
+				@rmdir($this -> TempDir);
 			}
 		}
 


### PR DESCRIPTION
The order was reversed. Windows is strict in this regard. A file must not be opened before another read or write access.